### PR TITLE
Python: query interpreter for more information.

### DIFF
--- a/include/functions/modules/python.h
+++ b/include/functions/modules/python.h
@@ -8,8 +8,8 @@
 #include "functions/common.h"
 
 void python_build_impl_tbl(void);
-extern struct func_impl_name impl_tbl_module_python[];
+extern const struct func_impl_name impl_tbl_module_python[];
 extern const struct func_impl_name impl_tbl_module_python3[];
 
-extern const struct func_impl_name impl_tbl_python_installation[];
+extern struct func_impl_name impl_tbl_python_installation[];
 #endif

--- a/include/json.h
+++ b/include/json.h
@@ -1,0 +1,89 @@
+/*
+ * From https://github.com/zserge/jsmn
+ * SPDX-FileCopyrightText: Copyright (c) 2010 Serge Zaitsev
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef JSMN_H
+#define JSMN_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef JSMN_STATIC
+#define JSMN_API static
+#else
+#define JSMN_API extern
+#endif
+
+/**
+ * JSON type identifier. Basic types are:
+ * 	o Object
+ * 	o Array
+ * 	o String
+ * 	o Other primitive: number, boolean (true/false) or null
+ */
+typedef enum {
+  JSMN_UNDEFINED = 0,
+  JSMN_OBJECT = 1 << 0,
+  JSMN_ARRAY = 1 << 1,
+  JSMN_STRING = 1 << 2,
+  JSMN_PRIMITIVE = 1 << 3
+} jsmntype_t;
+
+enum jsmnerr {
+  /* Not enough tokens were provided */
+  JSMN_ERROR_NOMEM = -1,
+  /* Invalid character inside JSON string */
+  JSMN_ERROR_INVAL = -2,
+  /* The string is not a full JSON packet, more bytes expected */
+  JSMN_ERROR_PART = -3
+};
+
+/**
+ * JSON token description.
+ * type		type (object, array, string etc.)
+ * start	start position in JSON data string
+ * end		end position in JSON data string
+ */
+typedef struct jsmntok {
+  jsmntype_t type;
+  int start;
+  int end;
+  int size;
+#ifdef JSMN_PARENT_LINKS
+  int parent;
+#endif
+} jsmntok_t;
+
+/**
+ * JSON parser. Contains an array of token blocks available. Also stores
+ * the string being parsed now and current position in that string.
+ */
+typedef struct jsmn_parser {
+  unsigned int pos;     /* offset in the JSON string */
+  unsigned int toknext; /* next token to allocate */
+  int toksuper;         /* superior token node, e.g. parent object or array */
+} jsmn_parser;
+
+/**
+ * Create JSON parser over an array of tokens
+ */
+JSMN_API void jsmn_init(jsmn_parser *parser);
+
+/**
+ * Run JSON parser. It parses a JSON data string into and array of tokens, each
+ * describing
+ * a single JSON object.
+ */
+JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
+                        jsmntok_t *tokens, const unsigned int num_tokens);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* JSMN_H */

--- a/include/lang/object.h
+++ b/include/lang/object.h
@@ -357,9 +357,20 @@ struct obj_external_program {
 struct obj_python_installation {
 	obj prog;
 
-	obj language_version;
-	obj sysconfig_paths;
-	obj sysconfig_vars;
+	struct python_info {
+		obj install_paths;
+		obj is_pypy;
+		obj is_venv;
+		obj link_libpython;
+		obj sysconfig_paths;
+		obj paths;
+		obj platform;
+		obj suffix;
+		obj limited_api_suffix;
+		obj variables;
+		obj language_version;
+		obj pure;
+	} info;
 };
 
 enum run_result_flags {

--- a/src/functions/modules/python.c
+++ b/src/functions/modules/python.c
@@ -5,46 +5,190 @@
 
 #include "compat.h"
 
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "embedded.h"
+#include "json.h"
+#include "log.h"
+
 #include "functions/modules/python.h"
 #include "functions/external_program.h"
 #include "lang/interpreter.h"
 #include "platform/filesystem.h"
 #include "platform/run_cmd.h"
 
-static const char *introspect_program =
-	"import sysconfig\n"
-	"print(sysconfig.get_python_version())\n";
+static inline bool json_streq(const char *buf, jsmntok_t *token,
+	const char *needle)
+{
+	if (token->type != JSMN_STRING)
+		return false;
+
+	return strncmp(buf + token->start, needle, token->end - token->start) == 0;
+}
+
+static jsmntok_t *parse_json_string(struct workspace *wk, obj *res,
+	const char *buffer, jsmntok_t *tok)
+{
+	assert(tok->type == JSMN_STRING);
+
+	*res = make_strn(wk, buffer + tok->start, tok->end - tok->start);
+	return tok + 1;
+}
+
+static jsmntok_t *parse_json_primitive(struct workspace *wk, obj *res,
+	const char *buffer, jsmntok_t *tok)
+{
+	assert(tok->type == JSMN_PRIMITIVE);
+
+	char first_char = buffer[tok->start];
+	switch(first_char) {
+		case 't':
+		case 'f':
+			make_obj(wk, res, obj_bool);
+			set_obj_bool(wk, *res, (first_char == 't'));
+			break;
+
+		default: {
+			char *end = ((char *)buffer) + tok->end;
+			int64_t value = strtoll(buffer + tok->start, &end, 10);
+			make_obj(wk, res, obj_number);
+			set_obj_number(wk, *res, value);
+			break;
+		}
+	}
+
+	return tok + 1;
+}
+
+static jsmntok_t *parse_json_object(struct workspace *wk, obj *res,
+	const char *buffer, jsmntok_t *tok)
+{
+	assert(tok->type == JSMN_STRING || tok->type == JSMN_PRIMITIVE);
+
+	switch(tok->type) {
+		case JSMN_STRING:
+			return parse_json_string(wk, res, buffer, tok);
+		case JSMN_PRIMITIVE:
+			return parse_json_primitive(wk, res, buffer, tok);
+		default:
+			return NULL;
+	}
+}
+
+static jsmntok_t *parse_json_dict(struct workspace *wk, obj *res,
+	const char *buffer, jsmntok_t *tok)
+{
+	jsmntok_t *cur_tok;
+
+	assert(res != NULL);
+	assert(tok->type == JSMN_OBJECT);
+
+	make_obj(wk, res, obj_dict);
+
+	cur_tok = tok + 1;
+
+	for(int i = 0; i < tok->size; ++i) {
+
+		/* Get the name. */
+		obj name_obj;
+		cur_tok = parse_json_string(wk, &name_obj, buffer, cur_tok);
+		if (!name_obj)
+			continue;
+
+		/* Get the value. */
+		obj value_obj;
+		cur_tok = parse_json_object(wk, &value_obj, buffer, cur_tok);
+		if (!value_obj)
+			continue;
+
+		obj_dict_set(wk, *res, name_obj, value_obj);
+	}
+
+	return cur_tok;
+}
 
 static bool
 introspect_python_interpreter(struct workspace *wk, const char *path,
 	struct obj_python_installation *python)
 {
 	struct run_cmd_ctx cmd_ctx = { 0 };
-	char *const args[] = { (char *)path, "-c", (char *)introspect_program, 0 };
+	const char *python_info_str = NULL;
+	jsmn_parser parser;
+	jsmntok_t *tokens = NULL;
+	size_t num_tokens = 2048;
+	int32_t parsed_tokens = 0;
+
+	python_info_str = embedded_get("python_info.py");
+	if (python_info_str == NULL) {
+		return false;
+	}
+
+	char *const args[] = { (char *)path, "-c", (char *)python_info_str, 0 };
 	if (!run_cmd_argv(&cmd_ctx, args, NULL, 0) || cmd_ctx.status != 0) {
 		return false;
 	}
 
-	size_t index = 0, buf_index = 0, max_buf_index = cmd_ctx.out.len;
-	char *buf = cmd_ctx.out.buf, *entry = cmd_ctx.out.buf;
-	while (buf_index != max_buf_index) {
-		if (buf[buf_index] == '\n') {
-			buf[buf_index] = '\0';
+	tokens = calloc(num_tokens, sizeof(jsmntok_t));
+	if (tokens == NULL) {
+		return false;
+	}
 
-			if (index == 0) {  /* language_version */
-				python->language_version = make_str(wk, entry);
-			}
+	jsmn_init(&parser);
 
-			entry = &buf[buf_index + 1];
-			index++;
-		} else {
-			buf_index++;
+	char *buf = cmd_ctx.out.buf;
+	parsed_tokens = jsmn_parse(&parser, buf, cmd_ctx.out.len, tokens, num_tokens);
+	if (parsed_tokens < 0) {
+		LOG_E("failed to parse python json info\n");
+		return false;
+	}
+
+	jsmntok_t root_token = tokens[0];
+	jsmntok_t *cur_tok = &tokens[1];
+
+	for (int i = 0; i < root_token.size; ++i) {
+
+		if (json_streq(buf, cur_tok, "variables")) {
+			++cur_tok;
+			cur_tok = parse_json_dict(wk, &python->info.variables, buf, cur_tok);
+		} else if (json_streq(buf, cur_tok, "paths")) {
+			++cur_tok;
+			cur_tok = parse_json_dict(wk, &python->info.paths, buf, cur_tok);
+		} else if (json_streq(buf, cur_tok, "sysconfig_paths")) {
+			++cur_tok;
+			cur_tok = parse_json_dict(wk, &python->info.sysconfig_paths, buf, cur_tok);
+		} else if (json_streq(buf, cur_tok, "install_paths")) {
+			++cur_tok;
+			cur_tok = parse_json_dict(wk, &python->info.install_paths, buf, cur_tok);
+		} else if (json_streq(buf, cur_tok, "version")) {
+			++cur_tok;
+			cur_tok = parse_json_string(wk, &python->info.language_version, buf, cur_tok);
+		} else if (json_streq(buf, cur_tok, "platform")) {
+			++cur_tok;
+			cur_tok = parse_json_string(wk, &python->info.platform, buf, cur_tok);
+		} else if (json_streq(buf, cur_tok, "is_pypy")) {
+			++cur_tok;
+			cur_tok = parse_json_primitive(wk, &python->info.is_pypy, buf, cur_tok);
+		} else if (json_streq(buf, cur_tok, "is_venv")) {
+			++cur_tok;
+			cur_tok = parse_json_primitive(wk, &python->info.is_venv, buf, cur_tok);
+		} else if (json_streq(buf, cur_tok, "link_libpython")) {
+			++cur_tok;
+			cur_tok = parse_json_primitive(wk, &python->info.link_libpython, buf, cur_tok);
+		} else if (json_streq(buf, cur_tok, "suffix")) {
+			++cur_tok;
+			cur_tok = parse_json_string(wk, &python->info.suffix, buf, cur_tok);
+		} else if (json_streq(buf, cur_tok, "limited_api_suffix")) {
+			++cur_tok;
+			cur_tok = parse_json_string(wk, &python->info.limited_api_suffix, buf, cur_tok);
 		}
 	}
 
-	bool success = buf[buf_index] == '\0';
+	bool success = (cur_tok != NULL);
 
 	run_cmd_ctx_destroy(&cmd_ctx);
+	free(tokens);
 
 	return success;
 }
@@ -103,11 +247,13 @@ func_module_python_find_installation(struct workspace *wk,
 		kw_required,
 		kw_disabler,
 		kw_modules,
+		kw_pure,
 	};
 	struct args_kw akw[] = {
 		[kw_required] = { "required", obj_bool },
 		[kw_disabler] = { "disabler", obj_bool },
 		[kw_modules] = { "modules", ARG_TYPE_ARRAY_OF | obj_string },
+		[kw_pure] = { "pure", obj_bool },
 		0
 	};
 	if (!interp_args(wk, args_node, NULL, ao, akw)) {
@@ -116,6 +262,11 @@ func_module_python_find_installation(struct workspace *wk,
 
 	bool required = !akw[kw_required].set || get_obj_bool(wk, akw[kw_required].val);
 	bool disabler = akw[kw_disabler].set && get_obj_bool(wk, akw[kw_disabler].val);
+	bool is_pure = true;
+
+	if (akw[kw_pure].set) {
+		is_pure = get_obj_bool(wk, akw[kw_pure].val);
+	}
 
 	const char *cmd = "python3";
 	if (ao[0].set) {
@@ -160,6 +311,10 @@ func_module_python_find_installation(struct workspace *wk,
 
 	make_obj(wk, res, obj_python_installation);
 	struct obj_python_installation *python = get_obj_python_installation(wk, *res);
+
+	make_obj(wk, &python->info.pure, obj_bool);
+	set_obj_bool(wk, python->info.pure, is_pure);
+
 	make_obj(wk, &python->prog, obj_external_program);
 	struct obj_external_program *ep = get_obj_external_program(wk, python->prog);
 	ep->found = found;
@@ -182,7 +337,7 @@ func_python_installation_language_version(struct workspace *wk, obj rcvr,
 		return false;
 	}
 
-	*res = get_obj_python_installation(wk, rcvr)->language_version;
+	*res = get_obj_python_installation(wk, rcvr)->info.language_version;
 	return true;
 }
 
@@ -214,7 +369,6 @@ func_module_python3_find_python(struct workspace *wk, obj rcvr, uint32_t args_no
 	return true;
 }
 
-
 static obj
 python_rcvr_transform(struct workspace *wk, obj rcvr)
 {
@@ -228,12 +382,11 @@ python_build_impl_tbl(void)
 	for (i = 0; impl_tbl_external_program[i].name; ++i) {
 		struct func_impl_name tmp = impl_tbl_external_program[i];
 		tmp.rcvr_transform = python_rcvr_transform;
-		impl_tbl_module_python[i] = tmp;
+		impl_tbl_python_installation[i] = tmp;
 	}
 }
 
-struct func_impl_name impl_tbl_module_python[] = {
-	[ARRAY_LEN(impl_tbl_external_program) - 1] =
+const struct func_impl_name impl_tbl_module_python[] = {
 	{ "find_installation", func_module_python_find_installation, tc_python_installation },
 	{ NULL, NULL },
 };
@@ -243,7 +396,8 @@ const struct func_impl_name impl_tbl_module_python3[] = {
 	{ NULL, NULL },
 };
 
-const struct func_impl_name impl_tbl_python_installation[] = {
+struct func_impl_name impl_tbl_python_installation[] = {
+	[ARRAY_LEN(impl_tbl_external_program) - 1] =
 	{ "language_version", func_python_installation_language_version, tc_string },
 	{ NULL, NULL },
 };

--- a/src/json.c
+++ b/src/json.c
@@ -1,0 +1,371 @@
+/*
+ * From https://github.com/zserge/jsmn
+ * SPDX-FileCopyrightText: Copyright (c) 2010 Serge Zaitsev
+ * SPDX-License-Identifier: MIT
+ */
+
+#define JSMN_STRICT
+#include "json.h"
+
+/**
+ * Allocates a fresh unused token from the token pool.
+ */
+static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser, jsmntok_t *tokens,
+                                   const size_t num_tokens) {
+  jsmntok_t *tok;
+  if (parser->toknext >= num_tokens) {
+    return NULL;
+  }
+  tok = &tokens[parser->toknext++];
+  tok->start = tok->end = -1;
+  tok->size = 0;
+#ifdef JSMN_PARENT_LINKS
+  tok->parent = -1;
+#endif
+  return tok;
+}
+
+/**
+ * Fills token type and boundaries.
+ */
+static void jsmn_fill_token(jsmntok_t *token, const jsmntype_t type,
+                            const int start, const int end) {
+  token->type = type;
+  token->start = start;
+  token->end = end;
+  token->size = 0;
+}
+
+/**
+ * Fills next available token with JSON primitive.
+ */
+static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
+                                const size_t len, jsmntok_t *tokens,
+                                const size_t num_tokens) {
+  jsmntok_t *token;
+  int start;
+
+  start = parser->pos;
+
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    switch (js[parser->pos]) {
+#ifndef JSMN_STRICT
+    /* In strict mode primitive must be followed by "," or "}" or "]" */
+    case ':':
+#endif
+    case '\t':
+    case '\r':
+    case '\n':
+    case ' ':
+    case ',':
+    case ']':
+    case '}':
+      goto found;
+    default:
+                   /* to quiet a warning from gcc*/
+      break;
+    }
+    if (js[parser->pos] < 32 || js[parser->pos] >= 127) {
+      parser->pos = start;
+      return JSMN_ERROR_INVAL;
+    }
+  }
+#ifdef JSMN_STRICT
+  /* In strict mode primitive must be followed by a comma/object/array */
+  parser->pos = start;
+  return JSMN_ERROR_PART;
+#endif
+
+found:
+  if (tokens == NULL) {
+    parser->pos--;
+    return 0;
+  }
+  token = jsmn_alloc_token(parser, tokens, num_tokens);
+  if (token == NULL) {
+    parser->pos = start;
+    return JSMN_ERROR_NOMEM;
+  }
+  jsmn_fill_token(token, JSMN_PRIMITIVE, start, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+  token->parent = parser->toksuper;
+#endif
+  parser->pos--;
+  return 0;
+}
+
+/**
+ * Fills next token with JSON string.
+ */
+static int jsmn_parse_string(jsmn_parser *parser, const char *js,
+                             const size_t len, jsmntok_t *tokens,
+                             const size_t num_tokens) {
+  jsmntok_t *token;
+
+  int start = parser->pos;
+
+  /* Skip starting quote */
+  parser->pos++;
+
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    char c = js[parser->pos];
+
+    /* Quote: end of string */
+    if (c == '\"') {
+      if (tokens == NULL) {
+        return 0;
+      }
+      token = jsmn_alloc_token(parser, tokens, num_tokens);
+      if (token == NULL) {
+        parser->pos = start;
+        return JSMN_ERROR_NOMEM;
+      }
+      jsmn_fill_token(token, JSMN_STRING, start + 1, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+      token->parent = parser->toksuper;
+#endif
+      return 0;
+    }
+
+    /* Backslash: Quoted symbol expected */
+    if (c == '\\' && parser->pos + 1 < len) {
+      int i;
+      parser->pos++;
+      switch (js[parser->pos]) {
+      /* Allowed escaped symbols */
+      case '\"':
+      case '/':
+      case '\\':
+      case 'b':
+      case 'f':
+      case 'r':
+      case 'n':
+      case 't':
+        break;
+      /* Allows escaped symbol \uXXXX */
+      case 'u':
+        parser->pos++;
+        for (i = 0; i < 4 && parser->pos < len && js[parser->pos] != '\0';
+             i++) {
+          /* If it isn't a hex character we have an error */
+          if (!((js[parser->pos] >= 48 && js[parser->pos] <= 57) ||   /* 0-9 */
+                (js[parser->pos] >= 65 && js[parser->pos] <= 70) ||   /* A-F */
+                (js[parser->pos] >= 97 && js[parser->pos] <= 102))) { /* a-f */
+            parser->pos = start;
+            return JSMN_ERROR_INVAL;
+          }
+          parser->pos++;
+        }
+        parser->pos--;
+        break;
+      /* Unexpected symbol */
+      default:
+        parser->pos = start;
+        return JSMN_ERROR_INVAL;
+      }
+    }
+  }
+  parser->pos = start;
+  return JSMN_ERROR_PART;
+}
+
+/**
+ * Parse JSON string and fill tokens.
+ */
+JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
+                        jsmntok_t *tokens, const unsigned int num_tokens) {
+  int r;
+  int i;
+  jsmntok_t *token;
+  int count = parser->toknext;
+
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    char c;
+    jsmntype_t type;
+
+    c = js[parser->pos];
+    switch (c) {
+    case '{':
+    case '[':
+      count++;
+      if (tokens == NULL) {
+        break;
+      }
+      token = jsmn_alloc_token(parser, tokens, num_tokens);
+      if (token == NULL) {
+        return JSMN_ERROR_NOMEM;
+      }
+      if (parser->toksuper != -1) {
+        jsmntok_t *t = &tokens[parser->toksuper];
+#ifdef JSMN_STRICT
+        /* In strict mode an object or array can't become a key */
+        if (t->type == JSMN_OBJECT) {
+          return JSMN_ERROR_INVAL;
+        }
+#endif
+        t->size++;
+#ifdef JSMN_PARENT_LINKS
+        token->parent = parser->toksuper;
+#endif
+      }
+      token->type = (c == '{' ? JSMN_OBJECT : JSMN_ARRAY);
+      token->start = parser->pos;
+      parser->toksuper = parser->toknext - 1;
+      break;
+    case '}':
+    case ']':
+      if (tokens == NULL) {
+        break;
+      }
+      type = (c == '}' ? JSMN_OBJECT : JSMN_ARRAY);
+#ifdef JSMN_PARENT_LINKS
+      if (parser->toknext < 1) {
+        return JSMN_ERROR_INVAL;
+      }
+      token = &tokens[parser->toknext - 1];
+      for (;;) {
+        if (token->start != -1 && token->end == -1) {
+          if (token->type != type) {
+            return JSMN_ERROR_INVAL;
+          }
+          token->end = parser->pos + 1;
+          parser->toksuper = token->parent;
+          break;
+        }
+        if (token->parent == -1) {
+          if (token->type != type || parser->toksuper == -1) {
+            return JSMN_ERROR_INVAL;
+          }
+          break;
+        }
+        token = &tokens[token->parent];
+      }
+#else
+      for (i = parser->toknext - 1; i >= 0; i--) {
+        token = &tokens[i];
+        if (token->start != -1 && token->end == -1) {
+          if (token->type != type) {
+            return JSMN_ERROR_INVAL;
+          }
+          parser->toksuper = -1;
+          token->end = parser->pos + 1;
+          break;
+        }
+      }
+      /* Error if unmatched closing bracket */
+      if (i == -1) {
+        return JSMN_ERROR_INVAL;
+      }
+      for (; i >= 0; i--) {
+        token = &tokens[i];
+        if (token->start != -1 && token->end == -1) {
+          parser->toksuper = i;
+          break;
+        }
+      }
+#endif
+      break;
+    case '\"':
+      r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
+      if (r < 0) {
+        return r;
+      }
+      count++;
+      if (parser->toksuper != -1 && tokens != NULL) {
+        tokens[parser->toksuper].size++;
+      }
+      break;
+    case '\t':
+    case '\r':
+    case '\n':
+    case ' ':
+      break;
+    case ':':
+      parser->toksuper = parser->toknext - 1;
+      break;
+    case ',':
+      if (tokens != NULL && parser->toksuper != -1 &&
+          tokens[parser->toksuper].type != JSMN_ARRAY &&
+          tokens[parser->toksuper].type != JSMN_OBJECT) {
+#ifdef JSMN_PARENT_LINKS
+        parser->toksuper = tokens[parser->toksuper].parent;
+#else
+        for (i = parser->toknext - 1; i >= 0; i--) {
+          if (tokens[i].type == JSMN_ARRAY || tokens[i].type == JSMN_OBJECT) {
+            if (tokens[i].start != -1 && tokens[i].end == -1) {
+              parser->toksuper = i;
+              break;
+            }
+          }
+        }
+#endif
+      }
+      break;
+#ifdef JSMN_STRICT
+    /* In strict mode primitives are: numbers and booleans */
+    case '-':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case 't':
+    case 'f':
+    case 'n':
+      /* And they must not be keys of the object */
+      if (tokens != NULL && parser->toksuper != -1) {
+        const jsmntok_t *t = &tokens[parser->toksuper];
+        if (t->type == JSMN_OBJECT ||
+            (t->type == JSMN_STRING && t->size != 0)) {
+          return JSMN_ERROR_INVAL;
+        }
+      }
+#else
+    /* In non-strict mode every unquoted value is a primitive */
+    default:
+#endif
+      r = jsmn_parse_primitive(parser, js, len, tokens, num_tokens);
+      if (r < 0) {
+        return r;
+      }
+      count++;
+      if (parser->toksuper != -1 && tokens != NULL) {
+        tokens[parser->toksuper].size++;
+      }
+      break;
+
+#ifdef JSMN_STRICT
+    /* Unexpected char in strict mode */
+    default:
+      return JSMN_ERROR_INVAL;
+#endif
+    }
+  }
+
+  if (tokens != NULL) {
+    for (i = parser->toknext - 1; i >= 0; i--) {
+      /* Unmatched opened object or array */
+      if (tokens[i].start != -1 && tokens[i].end == -1) {
+        return JSMN_ERROR_PART;
+      }
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Creates a new parser based over a given buffer with an array of tokens
+ * available.
+ */
+JSMN_API void jsmn_init(jsmn_parser *parser) {
+  parser->pos = 0;
+  parser->toknext = 0;
+  parser->toksuper = -1;
+}
+

--- a/src/lang/object.c
+++ b/src/lang/object.c
@@ -1635,7 +1635,42 @@ obj_to_s(struct workspace *wk, obj o, struct sbuf *sb)
 		if (prog->found) {
 			sbuf_pushs(wk, sb, ", cmd_array: ");
 			obj_to_s(wk, prog->cmd_array, sb);
-			sbuf_pushf(wk, sb, "version: %s", get_cstr(wk, py->language_version));
+
+			sbuf_pushs(wk, sb, ", info.install_paths: {");
+			obj_dict_foreach(wk, py->info.install_paths, &ctx, obj_to_s_dict_iter);
+
+			sbuf_pushs(wk, sb, "}, info.is_pypy: ");
+			obj_to_s(wk, py->info.is_pypy, sb);
+
+			sbuf_pushs(wk, sb, ", info.is_venv: ");
+			obj_to_s(wk, py->info.is_venv, sb);
+
+			sbuf_pushs(wk, sb, ", info.link_libpython: ");
+			obj_to_s(wk, py->info.link_libpython, sb);
+
+			sbuf_pushs(wk, sb, ", info.sysconfig_paths: {");
+			obj_dict_foreach(wk, py->info.sysconfig_paths, &ctx, obj_to_s_dict_iter);
+
+			sbuf_pushs(wk, sb, "}, info.paths: {");
+			obj_dict_foreach(wk, py->info.paths, &ctx, obj_to_s_dict_iter);
+
+			sbuf_pushs(wk, sb, "}, info.platform: ");
+			obj_to_s(wk, py->info.platform, sb);
+
+			sbuf_pushs(wk, sb, ", info.suffix: ");
+			obj_to_s(wk, py->info.suffix, sb);
+
+			sbuf_pushs(wk, sb, ", info.limited_api_suffix: ");
+			obj_to_s(wk, py->info.limited_api_suffix, sb);
+
+			sbuf_pushs(wk, sb, ", info.variables: {");
+			obj_dict_foreach(wk, py->info.variables, &ctx, obj_to_s_dict_iter);
+
+			sbuf_pushs(wk, sb, "}, info.language_version: ");
+			obj_to_s(wk, py->info.language_version, sb);
+
+			sbuf_pushs(wk, sb, ", info.pure: ");
+			obj_to_s(wk, py->info.pure, sb);
 		}
 
 		sbuf_pushs(wk, sb, ">");

--- a/src/meson.build
+++ b/src/meson.build
@@ -74,6 +74,7 @@ src = files(
     'error.c',
     'guess.c',
     'install.c',
+    'json.c',
     'log.c',
     'machine_file.c',
     'main.c',

--- a/src/script/meson.build
+++ b/src/script/meson.build
@@ -9,6 +9,7 @@ foreach s : [
     'global_options.meson',
     'per_project_options.meson',
     'vcs_tagger.meson',
+    'python_info.py'
 ]
     scripts_input += s
     scripts_cmdline += files(s) + [s]

--- a/src/script/python_info.py
+++ b/src/script/python_info.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+
+# NOTE: This is the script that Meson uses to query information from a
+# Python interpreter. It should be kept in-sync with Meson's version.
+
+# ignore all lints for this file, since it is run by python2 as well
+
+# type: ignore
+# pylint: disable=deprecated-module
+
+import sys
+
+# do not inject mesonbuild.scripts
+# python -P would work too, but is exclusive to >=3.11
+if sys.path[0].endswith('scripts'):
+    del sys.path[0]
+
+import json, os, sysconfig
+
+def get_distutils_paths(scheme=None, prefix=None):
+    import distutils.dist
+    distribution = distutils.dist.Distribution()
+    install_cmd = distribution.get_command_obj('install')
+    if prefix is not None:
+        install_cmd.prefix = prefix
+    if scheme:
+        install_cmd.select_scheme(scheme)
+    install_cmd.finalize_options()
+    return {
+        'data': install_cmd.install_data,
+        'include': os.path.dirname(install_cmd.install_headers),
+        'platlib': install_cmd.install_platlib,
+        'purelib': install_cmd.install_purelib,
+        'scripts': install_cmd.install_scripts,
+    }
+
+# On Debian derivatives, the Python interpreter shipped by the distribution uses
+# a custom install scheme, deb_system, for the system install, and changes the
+# default scheme to a custom one pointing to /usr/local and replacing
+# site-packages with dist-packages.
+# See https://github.com/mesonbuild/meson/issues/8739.
+#
+# We should be using sysconfig, but before 3.10.3, Debian only patches distutils.
+# So we may end up falling back.
+
+def get_install_paths():
+    if sys.version_info >= (3, 10):
+        scheme = sysconfig.get_default_scheme()
+    else:
+        scheme = sysconfig._get_default_scheme()
+
+    if sys.version_info >= (3, 10, 3):
+        if 'deb_system' in sysconfig.get_scheme_names():
+            scheme = 'deb_system'
+    else:
+        import distutils.command.install
+        if 'deb_system' in distutils.command.install.INSTALL_SCHEMES:
+            paths = get_distutils_paths(scheme='deb_system')
+            install_paths = get_distutils_paths(scheme='deb_system', prefix='')
+            return paths, install_paths
+
+    paths = sysconfig.get_paths(scheme=scheme)
+    empty_vars = {'base': '', 'platbase': '', 'installed_base': ''}
+    install_paths = sysconfig.get_paths(scheme=scheme, vars=empty_vars)
+    return paths, install_paths
+
+paths, install_paths = get_install_paths()
+
+def links_against_libpython():
+    # on versions supporting python-embed.pc, this is the non-embed lib
+    #
+    # PyPy is not yet up to 3.12 and work is still pending to export the
+    # relevant information (it doesn't automatically provide arbitrary
+    # Makefile vars)
+    if sys.version_info >= (3, 8) and not is_pypy:
+        variables = sysconfig.get_config_vars()
+        return bool(variables.get('LIBPYTHON', 'yes'))
+    else:
+        from distutils.core import Distribution, Extension
+        cmd = Distribution().get_command_obj('build_ext')
+        cmd.ensure_finalized()
+        return bool(cmd.get_libraries(Extension('dummy', [])))
+
+variables = sysconfig.get_config_vars()
+variables.update({'base_prefix': getattr(sys, 'base_prefix', sys.prefix)})
+
+is_pypy = '__pypy__' in sys.builtin_module_names
+
+if sys.version_info < (3, 0):
+    suffix = variables.get('SO')
+elif sys.version_info < (3, 8, 7):
+    # https://bugs.python.org/issue?@action=redirect&bpo=39825
+    from distutils.sysconfig import get_config_var
+    suffix = get_config_var('EXT_SUFFIX')
+else:
+    suffix = variables.get('EXT_SUFFIX')
+
+limited_api_suffix = None
+if sys.version_info >= (3, 2):
+    try:
+        from importlib.machinery import EXTENSION_SUFFIXES
+        limited_api_suffix = EXTENSION_SUFFIXES[1]
+    except Exception:
+        pass
+
+# pypy supports modules targetting the limited api but
+# does not use a special suffix to distinguish them:
+# https://doc.pypy.org/en/latest/cpython_differences.html#permitted-abi-tags-in-extensions
+if is_pypy:
+    limited_api_suffix = suffix
+
+print(json.dumps({
+  'variables': variables,
+  'paths': paths,
+  'sysconfig_paths': sysconfig.get_paths(),
+  'install_paths': install_paths,
+  'version': sysconfig.get_python_version(),
+  'platform': sysconfig.get_platform(),
+  'is_pypy': is_pypy,
+  'is_venv': sys.prefix != variables['base_prefix'],
+  'link_libpython': links_against_libpython(),
+  'suffix': suffix,
+  'limited_api_suffix': limited_api_suffix,
+}))


### PR DESCRIPTION
This commit adds the necessary machinery to allow the new `python_installation` object to query a Python interpreter for information about its installation.

Meson does this by passing a script to the interpreter which dumps its info to STDOUT as JSON, which it then parses.

I have copied the script that Meson uses and embedded it into muon using the existing embedding machinery. This script will need to be kept up to date with Meson's version.

I have also integrated jsmn(https://github.com/zserge/jsmn), a small c99 JSON parser with zero dependencies, into muon to allow the parsing of the script's STDOUT data.

Tests ran with no failures, but there aren't yet any tests whose behaviour is impacted by this functionality.

Feedback is very welcome! I am new to the muon codebase, so I'm sure I've made plenty of mistakes. I started this work because I wanted to give muon the ability to use `python_installation.extension_module` and some of the information that is queried will be necessary for that functionality.

