### PR TITLE
systemd fixes

### DIFF
--- a/src/functions/compiler.c
+++ b/src/functions/compiler.c
@@ -637,8 +637,7 @@ func_compiler_compute_int(struct workspace *wk, obj rcvr, uint32_t args_node, ob
 		"#include <stdio.h>\n"
 		"%s\n"
 		"int main(void) {\n"
-		"int d = (%s);\n"
-		"printf(\"%%d\", d);\n"
+		"printf(\"%%ld\", (long)(%s));\n"
 		"}\n",
 		compiler_check_prefix(wk, akw),
 		get_cstr(wk, an[0].val)


### PR DESCRIPTION
When attempting to build systemd with muon, I encountered two issues which these commits address.

In combination with the most recent Python related fix on the mailing list, systemd's meson scripts reach their use of i18n under muon before erroring out.

So I guess implementing i18n is next on the list :).

Please let me know if you would prefer that these patches be sent using the Sourcehut workflow. I am posting them here as I am more familiar with the GitHub workflow and I saw your recent mailing list post about PRs being accepted.