### PR TITLE
interpreter: Correct return value state handling

### DIFF
--- a/src/functions/common.c
+++ b/src/functions/common.c
@@ -763,6 +763,7 @@ func_obj_call(struct workspace *wk, struct obj_func *f, obj args, obj *res)
 	*res = wk->returned;
 	/* LO("%s returned %o\n", f->name, wk->returned); */
 	wk->returning = false;
+	wk->returned = 0;
 
 	if (ret && !typecheck_custom(wk, wk->return_node, *res, f->return_type,
 		"function returned invalid type, expected %s, got %s")) {

--- a/src/script/modules/_test.meson
+++ b/src/script/modules/_test.meson
@@ -100,6 +100,17 @@ func multi_return(k str) -> int
     return d[k]
 endfunc
 
+func returns_string() -> str
+  return '10'
+endfunc
+
+# this should return void and muon should not raise an error stating that
+# it expected a return of 'str' due to the internal call to `returns_string`
+func returns_void()
+  val_str = returns_string()
+  message(val_str)
+endfunc
+
 func project() -> dict[any]
     return meson.project()
 endfunc
@@ -120,5 +131,6 @@ return {
     'glob_arg': glob_arg,
     'typed_list': typed_list,
     'multi_return': multi_return,
+    'returns_void': returns_void,
     'project': project,
 }

--- a/tests/project/muon/script_module/meson.build
+++ b/tests/project/muon/script_module/meson.build
@@ -84,6 +84,9 @@ assert(m.multi_return('a') == 1)
 assert(m.multi_return('b') == 2)
 assert(m.multi_return('c') == 0)
 
+# test internal calls not changing interpreter state.
+m.returns_void()
+
 # test meson.project()
 assert('c' not in m.project()['compilers'])
 add_languages('c')


### PR DESCRIPTION
In cases where a script module function returns void, while also calling an internal function which does not return void, the return type of the internal function ends up as the expected return type of the outer void-returning function, yielding type failure.

Admittedly this is a very contrived example and only likely to show up when prototyping new script modules but it was nonetheless causing me difficulties in exactly that situation so I have fixed it and extended the script_module test to cover this case.