### PR TITLE
compilers: pass _FILE_OFFSET_BITS on posix

### DIFF
--- a/src/compilers.c
+++ b/src/compilers.c
@@ -681,6 +681,13 @@ compiler_posix_args_define(const char *define)
 	return &args;
 }
 
+static const struct args *
+compiler_posix_args_always(void)
+{
+	COMPILER_ARGS({ "-D_FILE_OFFSET_BITS=64" });
+	return &args;
+}
+
 /* gcc compilers */
 
 static const struct args *
@@ -1232,6 +1239,7 @@ build_compilers(void)
 	posix.args.include = compiler_posix_args_include;
 	posix.args.include_system = compiler_posix_args_include;
 	posix.args.define = compiler_posix_args_define;
+	posix.args.always = compiler_posix_args_always;
 	posix.default_linker = linker_posix;
 	posix.default_static_linker = static_linker_ar_posix;
 


### PR DESCRIPTION
With this patch, systemd can be successfully built with muon if one disables internationalisation via `-Dtranslations=false`.

Feedback very welcome. This passes the testsuite but I'm not sure it's the right implementation. I looked at what meson does and tried to port the logic into muon.

A script implementation of the `i18n` module is forthcoming although that's proving to be a more complex affair than I had previously thought.