### PR TITLE
Windows: Add missing include for `getenv`

### DIFF
--- a/src/platform/windows/filesystem.c
+++ b/src/platform/windows/filesystem.c
@@ -13,6 +13,7 @@
 #include <io.h>
 #include <errno.h>
 #include <assert.h>
+#include <stdlib.h>
 
 #include "log.h"
 #include "lang/string.h"


### PR DESCRIPTION
Without this `getenv` might be defaulted to return int causing pointers returned by it to be truncated leading to invalid access.

I'm not sure if others have run into this, but it seems to be systematic under VS2022, causing the first access in `fs_find_cmd` to a pointer returned from `getenv` to segfault.