### PR TITLE
deps.c: Fix truncation in deps parser.

### DIFF
--- a/src/external/samurai/deps.c
+++ b/src/external/samurai/deps.c
@@ -136,7 +136,7 @@ src_fread(void *buf, size_t sz, size_t n, struct seekable_source *src)
 	return r;
 }
 
-static char
+static int
 src_getc(struct seekable_source *src)
 {
 	if (src->i >= src->src.len) {


### PR DESCRIPTION
On aarch64 (under gcc-12) the value returned by src_getc is and'ed with 0xff causing the resulting comparisons to fail (when they otherwise should succeed). On valid depfiles, this causes muon, when run in samu mode, to spew the following:

`samu: bad depfile: expected ':', saw '�'`

It also causes muon to always perform a full rebuild even when it doesn't need to as the return value of `samu_depsparse` is always `NULL`.

This commit fixes this issue. I'm not sure of its impact outside of the context of aarch64 Linux. Pushing this up for review while I look into that.
