### PR TITLE
Fix build on android

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ version_info.set('meson_compat', '1.1')
 platform = host_machine.system()
 if (
     platform in [
+        'android',
         'cygwin',
         'darwin',
         'freebsd',


### PR DESCRIPTION
```
The Meson build system
Version: 1.3.0
Source dir: /home/user/Projects/muon
Build dir: /home/user/Projects/muon/setup
Build type: cross build
Project name: muon
Project version: 0.2.0
C compiler for the host machine: aarch64-linux-android30-clang (clang 14.0.1 "Android (8075178, based on r437112b) clang version 14.0.1 (https://android.googlesource.com/toolchain/llvm-project 8671348b81b95fc603505dfc881b45103bee1731)")
C linker for the host machine: aarch64-linux-android30-clang ld.lld 14.0.1
C compiler for the build machine: ccache cc (gcc 13.2.1 "cc (GCC) 13.2.1 20240316 (Red Hat 13.2.1-7)")
C linker for the build machine: cc ld.bfd 2.40-14
Build machine cpu family: x86_64
Build machine cpu: x86_64
Host machine cpu family: aarch64
Host machine cpu: aarch64
Target machine cpu family: aarch64
Target machine cpu: aarch64
Program git found: YES (/usr/bin/git)
Compiler for C supports arguments -Wendif-labels: YES 
Compiler for C supports arguments -Wimplicit-fallthrough=2: NO 
Compiler for C supports arguments -Winit-self: YES 
Compiler for C supports arguments -Wlogical-op: NO 
Compiler for C supports arguments -Wmissing-include-dirs: YES 
Compiler for C supports arguments -Wno-missing-braces: YES 
Compiler for C supports arguments -Wno-missing-field-initializers: YES 
Compiler for C supports arguments -Wno-unused-parameter: YES 
Compiler for C supports arguments -Wold-style-definition: YES 
Compiler for C supports arguments -Woverflow: YES 
Compiler for C supports arguments -Wstrict-aliasing=2: YES 
Compiler for C supports arguments -Wstrict-prototypes: YES 
Compiler for C supports arguments -Wundef: YES 
Compiler for C supports arguments -Wvla: YES 
Compiler for C supports arguments -fstrict-aliasing: YES 
Configuring version.c using configuration
Found pkg-config: NO
Found CMake: NO
Run-time dependency libcurl found: NO (tried pkgconfig and cmake)
Run-time dependency libarchive found: NO (tried pkgconfig and cmake)
Run-time dependency libpkgconf found: NO (tried pkgconfig and cmake)
Looking for a fallback subproject for the dependency libpkgconf
Neither a subproject directory nor a pkgconf.wrap file was found.
Subproject  pkgconf is buildable: NO (disabling)
Dependency libpkgconf from subproject pkgconf found: NO (subproject failed to configure)
Dependency bestline skipped: feature bestline disabled
Run-time dependency tinyjson found: NO (tried pkgconfig and cmake)
Looking for a fallback subproject for the dependency tinyjson
Building fallback subproject with default_library=static

Executing subproject tinyjson 

tinyjson| Project name: tiny-json
tinyjson| Project version: undefined
tinyjson| C compiler for the host machine: aarch64-linux-android30-clang (clang 14.0.1 "Android (8075178, based on r437112b) clang version 14.0.1 (https://android.googlesource.com/toolchain/llvm-project 8671348b81b95fc603505dfc881b45103bee1731)")
tinyjson| C linker for the host machine: aarch64-linux-android30-clang ld.lld 14.0.1
tinyjson| C compiler for the build machine: ccache cc (gcc 13.2.1 "cc (GCC) 13.2.1 20240316 (Red Hat 13.2.1-7)")
tinyjson| C linker for the build machine: cc ld.bfd 2.40-14
tinyjson| Build targets in project: 3
tinyjson| Subproject tinyjson finished.

Dependency tinyjson found: YES undefined (overridden)
Run-time dependency tracy found: NO (tried pkgconfig and cmake)
Program python3 found: YES (/usr/bin/python3)
Program test.sh found: YES (/home/user/Projects/muon/tests/fmt/editorconfig/test.sh)
Program afl-fuzz found: NO
Program runner.sh found: YES (/home/user/Projects/muon/tests/project/runner.sh)
Program scdoc found: YES (/usr/local/bin/scdoc)

Executing subproject meson-docs 

meson-docs| Project name: meson
meson-docs| Project version: undefined
meson-docs| Program docs/genrefman.py found: YES (/home/user/Projects/muon/subprojects/meson-docs/docs/genrefman.py)
meson-docs| Build targets in project: 8
meson-docs| Subproject meson-docs finished.

Build targets in project: 8

muon 0.2.0

    libcurl    : false
    libarchive : false
    libpkgconf : false
    bestline   : false
    docs       : true

  Subprojects
    meson-docs : YES
    pkgconf    : NO
                 Neither a subproject directory nor a pkgconf.wrap file was found.
    tinyjson   : YES

  User defined options
    Cross files: android-aarch64

Found ninja-1.11.1 at /usr/bin/ninja
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```

Cross-compilation output with this PR applied. Fixes https://todo.sr.ht/~lattis/muon/116