### PR TITLE
Various improvements for compilation with cl.exe

### DIFF
--- a/src/functions/compiler.c
+++ b/src/functions/compiler.c
@@ -1852,6 +1852,8 @@ func_compiler_get_argument_syntax(struct workspace *wk, obj self, obj *res)
 	case compiler_gcc:
 	case compiler_clang:
 	case compiler_apple_clang: syntax = "gcc"; break;
+	case compiler_clang_cl:
+	case compiler_msvc: syntax = "msvc"; break;
 	default: syntax = "other"; break;
 	}
 


### PR DESCRIPTION
 * mimic what meson does for /std
 * add /nologo when linking
 * specify target platform when linking
 * improve get_argument_syntax() method
 * fix link stage in linker_link_args_input_output(): input and output were swapped