### PR TITLE
windows: resolve app exec link reparse points

### DIFF
--- a/include/platform/path.h
+++ b/include/platform/path.h
@@ -53,4 +53,5 @@ void path_executable(struct workspace *wk, struct tstr *buf, const char *path);
 void _path_normalize(struct workspace *wk, struct tstr *buf, bool optimize);
 void path_to_posix(char *path);
 bool path_begins_with_win32_drive(const char *path);
+bool path_wide_begins_with_win32_drive(const wchar_t *path);
 #endif

--- a/src/platform/path.c
+++ b/src/platform/path.c
@@ -465,15 +465,22 @@ path_executable(struct workspace *wk, struct tstr *buf, const char *path)
 	}
 }
 
+#define path_begins_with_win32_drive_impl(path, p) \
+	if (!path[0] || !path[1] || !path[2]) { \
+		return false; \
+	} \
+	\
+	/* c:/ or c:\ case insensitive */ \
+	return (((path[0] >= p## 'a') && (path[0] <= p## 'z')) || ((path[0] >= p## 'A') && (path[0] <= p## 'Z'))) && (path[1] == p## ':') \
+	       && ((path[2] == p## '/') || (path[2] == p## '\\'));
+
 bool
 path_begins_with_win32_drive(const char *path)
 {
-	if (!path[0] || !path[1] || !path[2]) {
-		return false;
-	}
-
-	/* c:/ or c:\ case insensitive */
-	return (((path[0] >= 'a') && (path[0] <= 'z')) || ((path[0] >= 'A') && (path[0] <= 'Z'))) && (path[1] == ':')
-	       && ((path[2] == '/') || (path[2] == '\\'));
+	path_begins_with_win32_drive_impl(path, );
 }
 
+bool path_wide_begins_with_win32_drive(const wchar_t *path)
+{
+	path_begins_with_win32_drive_impl(path, L);
+}


### PR DESCRIPTION
fixes https://github.com/muon-build/muon/issues/171

```c
  dbg entering subproject 'freetype2'
  Trying to resolve file reparse point: C:/Users/admin/AppData/Local/Microsoft/WindowsApps/python3.exe
  Resolved file as a reparse point: C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.2544.0_x64__qbz5n2kfra8p0\python3.12.exe
  dbg executing: C:/Users/admin/AppData/Local/Microsoft/WindowsApps/python3.exe E:/dev/muon-freetype-test/subprojects/freetype-2.13.3/builds/meson/extract_freetype_version.py include/freetype/freetype.h
  dbg env: MUON_PATH='E:/dev/muon/buildDir/muon.exe' MESONINTROSPECT='E:/dev/muon/buildDir/muon.exe meson introspect' MESON_BUILD_ROOT='E:/dev/muon-freetype-test/build' MESON_SOURCE_ROOT='E:/dev/muon-freetype-test' MESON_SUBDIR='subprojects/freetype-2.13.3'
  freetype2 version: 2.13.3
  ```