### PR TITLE
fix null samu_main definition

### DIFF
--- a/src/external/samurai_null.c
+++ b/src/external/samurai_null.c
@@ -11,7 +11,7 @@
 const bool have_samurai = false;
 
 bool
-samu_main(int argc, char *argv[], struct samu_opts *opts)
+samu_main(struct workspace *wk, int argc, char *argv[], struct samu_opts *opts)
 {
 	LOG_W("samurai not enabled");
 	return false;


### PR DESCRIPTION
When using an external compiled samurai binary, the build fails because the definition for samu_main has changed:

 ../muon/src/external/samurai_null.c:14:1: error: conflicting types for ‘samu_main’; have ‘_Bool(int,  char **, struct samu_opts *)’
   14 | samu_main(int argc, char *argv[], struct samu_opts *opts)
      | ^~~~~~~~~
In file included from ../muon/src/external/samurai_null.c:8: ../muon/include/external/samurai.h:26:6: note: previous declaration of ‘samu_main’ with type ‘_Bool(struct workspace *, int,  char **, struct samu_opts *)’
   26 | bool samu_main(struct workspace *wk, int argc, char *argv[], struct samu_opts *opts);
      |      ^~~~~~~~~

fixes: deec7f75218e ("wip 2")