### PR TITLE
Fix command-line options to use last value instead of first

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -473,7 +473,7 @@ set_option(struct workspace *wk, obj opt, obj new_val, enum option_value_source 
 	// Only set options that have not been set from a source with higher
 	// precedence.
 
-	if (o->source >= source) {
+	if (o->source > source) {
 		return true;
 	}
 


### PR DESCRIPTION
When the same option is specified multiple times using -D on the command line, the last value should override earlier values. This matches the behavior of meson and most other command-line tools.

Previously, set_option() would reject updates from sources with equal precedence (>=), causing the first value to be kept. Changed to only reject updates from sources with strictly higher precedence (>), allowing same-source updates to proceed.

Closes #199 