### PR TITLE
Add _FILE_OFFSET_BITS=64 for 32-bit systems

### DIFF
--- a/src/backend/common_args.c
+++ b/src/backend/common_args.c
@@ -15,6 +15,7 @@
 #include "functions/build_target.h"
 #include "lang/object_iterators.h"
 #include "log.h"
+#include "machines.h"
 #include "options.h"
 #include "platform/assert.h"
 #include "platform/filesystem.h"
@@ -291,6 +292,27 @@ ca_setup_optional_b_args_compiler(struct workspace *wk,
 	}
 }
 
+static void
+ca_setup_largefile_args(struct workspace *wk, obj comp, const struct obj_build_target *tgt, obj args)
+{
+	const struct machine_definition *machine = machine_definitions[tgt->machine];
+
+	// Enable transparent large-file-support for 32-bit UNIX systems.
+	// This matches Meson's behavior for compatibility.
+	// Reference: https://github.com/mesonbuild/meson/blob/4bbd1ef923e995cd88c255cef65649ab8b07cfc6/mesonbuild/compilers/compilers.py#L1169
+	//
+	// Skip for MSVC (uses explicit 64-bit APIs) and macOS (64-bit only).
+	// glibc, musl, uclibc, and all BSD libcs support this.
+	// On Android, support for transparent LFS is available depending on Bionic version.
+	const struct args *arg_syntax = toolchain_compiler_argument_syntax(wk, comp);
+	bool is_msvc = arg_syntax && arg_syntax->len > 0 && strcmp(arg_syntax->args[0], "msvc") == 0;
+	bool is_darwin = machine->sys == machine_system_darwin;
+
+	if (!is_msvc && !is_darwin && machine->address_bits == 32) {
+		push_args(wk, args, toolchain_compiler_define(wk, comp, "_FILE_OFFSET_BITS=64"));
+	}
+}
+
 static obj
 ca_get_base_compiler_args(struct workspace *wk,
 	const struct project *proj,
@@ -314,6 +336,7 @@ ca_get_base_compiler_args(struct workspace *wk,
 	ca_get_werror_args(wk, comp, proj, tgt, args);
 
 	ca_setup_optional_b_args_compiler(wk, comp, proj, tgt, &buildtype, args);
+	ca_setup_largefile_args(wk, comp, tgt, args);
 
 	{ /* option args (from option('x_args')) */
 		ca_get_option_compile_args(wk, comp, proj, tgt, args);


### PR DESCRIPTION
Match Meson's default behavior by enabling large-file-support on 32-bit systems (except MSVC and macOS).

This also fixes [systemd build for openSUSE Tumbleweed](https://build.opensuse.org/package/live_build_log/home:VaiTon:muon-rebuild:devel/systemd/openSUSE_Tumbleweed/x86_64).
