### PR TITLE
gnome: Implement generate_gir function

### DIFF
--- a/src/script/modules/gnome.meson
+++ b/src/script/modules/gnome.meson
@@ -185,7 +185,7 @@ func compile_resources(
 endfunc
 
 func generate_gir(
-    targets glob[exe|both_libs|build_tgt],
+    targets glob[exe],
     install bool: true,
     build_by_default bool: true,
     extra_args listify[str]: [],


### PR DESCRIPTION
- Complete implementation of gnome.generate_gir()
- Generates both .gir and .typelib files

Closes #205
