### PR TITLE
fix regressions on macos 10.14 mojave

### DIFF
--- a/include/datastructures/seg_list.h
+++ b/include/datastructures/seg_list.h
@@ -77,19 +77,21 @@ uint32_t sl_slots_in_segment(uint32_t segment_index);
 uint32_t sl_capacity_for_segment_count(uint32_t segment_count);
 uint32_t sl_segment_count_for_capacity(uint32_t capacity);
 
-#define sl_for_named(__sl, __type, __it)                                                          \
-	for (struct {                                                                             \
-		     uint32_t seg, slot, idx;                                                     \
-		     __type *it;                                                                  \
-	     } __it                                                                               \
-		= { 0 };                                                                          \
-		__it.seg < (__sl)->segs_used;                                                     \
-		++__it.seg)                                                                       \
+#define sl_for_named(__sl, __type, __it, ...) {                                                   \
+	struct {                                                                                  \
+		uint32_t seg, slot, idx;                                                          \
+		__type *it;                                                                       \
+	} __it = { 0 };                                                                           \
+	for (; __it.seg < (__sl)->segs_used; ++__it.seg) {                                        \
 		for (__it.slot = 0, __it.it = &((__type *)(__sl)->segments[__it.seg])[__it.slot]; \
 			__it.slot < sl_slots_in_segment(__it.seg) && __it.idx < (__sl)->len       \
 			&& (__it.it = &((__type *)(__sl)->segments[__it.seg])[__it.slot], 1);     \
-			++__it.slot, ++__it.idx)
+			++__it.slot, ++__it.idx) {                                                \
+			__VA_ARGS__                                                               \
+		}                                                                                 \
+	}                                                                                         \
+}
 
-#define sl_for(__sl, __type) sl_for_named(__sl, __type, it)
+#define sl_for(__sl, __type, ...) sl_for_named(__sl, __type, it, __VA_ARGS__)
 
 #endif

--- a/src/datastructures/hash.c
+++ b/src/datastructures/hash.c
@@ -202,7 +202,7 @@ hash_resize(struct arena *a, struct arena *a_scratch, struct hash *h, uint32_t n
 
 	prepare_table(a, h);
 
-	sl_for(&tmp, struct hash_elem) {
+	sl_for(&tmp, struct hash_elem, {
 		void *key = sl_get_(sl_cast(&h->keys), it.it->keyi, h->key_size);
 		// printf("probing %.*s\n", (int)((struct strkey *)key)->len, ((struct strkey *)key)->str);
 
@@ -217,10 +217,12 @@ hash_resize(struct arena *a, struct arena *a_scratch, struct hash *h, uint32_t n
 		*meta = hv & 0x7f;
 
 		assert(k_full(*meta));
-	}
+	})
 
 #if 0
-	sl_for(h->meta, uint8_t) {
+	// Note: compile error prior to sl_for refactoring:
+	// error: macro 'sl_get' requires 3 arguments, but only 2 given
+	sl_for(h->meta, uint8_t, {
 		bool full = k_full(*it.it);
 		struct hash_elem *ohe = (full ? sl_get(h->e, it.idx) : 0);
 		struct strkey *key = (full ? sl_get(h->keys, ohe->keyi) : 0);
@@ -232,7 +234,7 @@ hash_resize(struct arena *a, struct arena *a_scratch, struct hash *h, uint32_t n
 			key ? key->str : 0,
 			full ? "=>" : "",
 			full ? (int)ohe->val : 0);
-	}
+	})
 #endif
 }
 

--- a/src/script/runtime/toolchains.meson
+++ b/src/script/runtime/toolchains.meson
@@ -178,11 +178,11 @@ toolchain.register_linker(
 )
 
 toolchain.register_linker(
-    'lld-apple',
+    'ld-apple',
     inherit: 'ld-posix',
-    exe: 'lld',
+    exe: 'ld',
     detect: func(out str) -> int
-        return 'Apple' in out ? 100 : 0
+        return 'Apple' in out or 'macos' in out.to_lower() ? 100 : 0
     endfunc,
     handlers: {
         'allow_shlib_undefined': ['-undefined', 'dynamic_lookup'],
@@ -194,10 +194,17 @@ toolchain.register_linker(
             return ['-fsanitize=' + s1]
         endfunc,
         'shared_module': ['-bundle'],
+        'version': ['-v'],
         'whole_archive': func(_c compiler, s1 str) -> list[str]
             return ['-force_load', s1]
         endfunc,
     },
+)
+
+toolchain.register_linker(
+    'lld-apple',
+    inherit: 'ld-apple',
+    exe: 'lld',
 )
 
 toolchain.register_linker(
@@ -484,7 +491,11 @@ toolchain.register_compiler(
                 return 'lld-link'
             endif
         elif m.system() == 'darwin' or 'Apple' in c.version_raw()
-            return 'lld-apple'
+            if find_program('lld', required: false).found()
+                return 'lld-apple'
+            else
+                return 'ld-apple'
+            endif
         else
             return 'lld'
         endif
@@ -653,6 +664,10 @@ toolchain.register_compiler(
     'nasm',
     exe: {'nasm': 'nasm'},
     detect: func(out str) -> int
+        if 'error: unable to find utility "nasm"' in out
+            # /usr/bin/nasm xcrun stub exists but an actual nasm isn't installed
+            return 0
+        endif
         return 'NASM' in out ? 100 : 1
     endfunc,
     linker: 'ld-posix',


### PR DESCRIPTION
fix regressions on x86_64-apple-darwin18.7.0

- clang-1100, apple-ld, detect non-functional nasm

```
finished 402 tests, 2 expected fail, 0 fail, 25 skipped
```
Side note... although the dozen or so lines to support apple-ld wasn't a big deal, it would be more succinct if muon were to optionally support arrays for toolchain executables:
```
exe: ['lld', 'ld'],
```
and similar syntax for `exe` maps:
```
exe: {
    'c': ['cl', 'clang-cl'],
    'cpp': ['cl', 'clang-cl'],
},
```
Prior to the toolchain scripting overhaul, muon used to try each binary in a C array until one worked.