### PR TITLE
speed up tcc test jobs on linux

### DIFF
--- a/.github/workflows/tcc.yml
+++ b/.github/workflows/tcc.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         git clone --depth 1 https://github.com/muon-build/tcc
         cd tcc
-        ./configure --prefix="$HOME/tcc-install" && make && make install
+        ./configure --prefix="$HOME/tcc-install" && make -j4 && make install
     - name: 'muon ci with tcc'
       run: |
         export CC="$HOME/tcc-install/bin/tcc"
@@ -79,7 +79,7 @@ jobs:
       run: |
         git clone --depth 1 https://github.com/muon-build/tcc
         cd tcc
-        ./configure --prefix="$HOME/tcc-install" && make && make install
+        ./configure --prefix="$HOME/tcc-install" && make -j4 && make install
     - name: 'muon ci with tcc'
       run: |
         export CC="$HOME/tcc-install/bin/tcc"


### PR DESCRIPTION
Building the tcc compiler itself on tcc-ubuntu-arm and tcc-ubuntu-x86_64 is 5 seconds faster with `make -j4`.