### PR TITLE
lang: fix crash when reporting errors with null bytes

### DIFF
--- a/src/lang/lexer.c
+++ b/src/lang/lexer.c
@@ -5,6 +5,7 @@
 
 #include "compat.h"
 
+#include <ctype.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdlib.h>
@@ -149,8 +150,7 @@ is_skipchar(const char c)
 static void
 lexer_push_fmt_raw_block(struct lexer *lexer, uint32_t start)
 {
-	obj s = make_strn(
-		lexer->wk, &lexer->src[lexer->fmt.raw_block_start], (start - 1) - lexer->fmt.raw_block_start);
+	obj s = make_strn(lexer->wk, &lexer->src[lexer->fmt.raw_block_start], (start - 1) - lexer->fmt.raw_block_start);
 
 	// XXX: We have to dup the array each time so that the parser can
 	// correctly reset the lexer using just value semantics
@@ -159,7 +159,6 @@ lexer_push_fmt_raw_block(struct lexer *lexer, uint32_t start)
 	lexer->fmt.raw_blocks = dup;
 	obj_array_push(lexer->wk, lexer->fmt.raw_blocks, s);
 }
-
 
 static void
 lex_advance(struct lexer *lexer)
@@ -241,6 +240,17 @@ MUON_ATTR_FORMAT(printf, 3, 4) lex_error_token(struct lexer *lexer, struct token
 	va_end(args);
 }
 
+static void
+lex_error_unexpected_char(struct lexer *lexer, struct token *token)
+{
+	if (!isprint(lexer->src[lexer->i])) {
+		lex_error_token(
+			lexer, token, "unexpected unprintable character 0x%02x", (unsigned char)lexer->src[lexer->i]);
+	} else {
+		lex_error_token(lexer, token, "unexpected character '%c'", lexer->src[lexer->i]);
+	}
+}
+
 /******************************************************************************
 * fmt related
 ******************************************************************************/
@@ -291,11 +301,23 @@ lexer_push_token_fmt(struct lexer *lexer, struct node_fmt_ws *ws, uint32_t pos)
 {
 	if (lexer->fmt.range) {
 		if (!lexer->fmt.range_pushed.start && pos >= lexer->fmt.range->start) {
-			L("%p, %d - %d - %d %d %d", (void*)lexer, lexer->fmt.range->start, pos, lexer->fmt.range->end, lexer->fmt.range_pushed.start, lexer->fmt.range_pushed.end);
+			L("%p, %d - %d - %d %d %d",
+				(void *)lexer,
+				lexer->fmt.range->start,
+				pos,
+				lexer->fmt.range->end,
+				lexer->fmt.range_pushed.start,
+				lexer->fmt.range_pushed.end);
 			lexer_push_whitespace_packed(lexer, ws, 0, node_fmt_ws_flag_fmt_on);
 			lexer->fmt.range_pushed.start = true;
 		} else if (!lexer->fmt.range_pushed.end && pos >= lexer->fmt.range->end) {
-			L("%p, %d - %d - %d %d %d", (void*)lexer, lexer->fmt.range->start, pos, lexer->fmt.range->end, lexer->fmt.range_pushed.start, lexer->fmt.range_pushed.end);
+			L("%p, %d - %d - %d %d %d",
+				(void *)lexer,
+				lexer->fmt.range->start,
+				pos,
+				lexer->fmt.range->end,
+				lexer->fmt.range_pushed.start,
+				lexer->fmt.range_pushed.end);
 			lexer_push_whitespace_packed(lexer, ws, 0, node_fmt_ws_flag_fmt_off);
 			lexer->fmt.range_pushed.end = true;
 		}
@@ -937,7 +959,7 @@ restart:
 		break;
 	default:
 unexpected_character:
-		lex_error_token(lexer, token, "unexpected character: '%c'", lexer->src[lexer->i]);
+		lex_error_unexpected_char(lexer, token);
 		break;
 	}
 
@@ -955,7 +977,6 @@ lexer_next(struct lexer *lexer, struct token *token)
 	// 	token->flags |= lexer->fmt.in_range ? token_flag_fmt_on : token_flag_fmt_off;
 	// 	lexer->fmt.range_border_crossed = false;
 	// }
-
 }
 
 void
@@ -968,7 +989,7 @@ lexer_init(struct lexer *lexer, struct workspace *wk, const struct source *src, 
 		.mode = mode,
 	};
 
-	if (src->len >= 3 && memcmp(src->src, (uint8_t []){ 0xef, 0xbb, 0xbf }, 3) == 0) {
+	if (src->len >= 3 && memcmp(src->src, (uint8_t[]){ 0xef, 0xbb, 0xbf }, 3) == 0) {
 		lexer->mode |= lexer_mode_bom_error;
 	}
 
@@ -1164,7 +1185,7 @@ restart:
 		break;
 	default:
 unexpected_character:
-		lex_error_token(lexer, token, "unexpected character: '%c'", lexer->src[lexer->i]);
+		lex_error_unexpected_char(lexer, token);
 		break;
 	}
 

--- a/src/lang/parser.c
+++ b/src/lang/parser.c
@@ -376,7 +376,8 @@ parse_advance(struct parser *p)
 	}
 
 	while (p->current.type == token_type_error) {
-		parse_error(p, &p->current.location, "%s", get_cstr(p->wk, p->current.data.str));
+		const struct str *ss = get_str(p->wk, p->current.data.str);
+		parse_error(p, &p->current.location, "%.*s", ss->len, ss->s);
 		p->err.unwinding = false;
 		lexer_next(&p->lexer, &p->current);
 	}
@@ -1435,7 +1436,8 @@ relex:
 	p->lexer.cm_mode = cm_lexer_mode_default;
 
 	while (p->current.type == token_type_error) {
-		parse_error(p, &p->current.location, "%s", get_cstr(p->wk, p->current.data.str));
+		const struct str *ss = get_str(p->wk, p->current.data.str);
+		parse_error(p, &p->current.location, "%.*s", ss->len, ss->s);
 		p->err.unwinding = false;
 		prev_lexer = p->lexer;
 		cm_lexer_next(&p->lexer, &p->current);


### PR DESCRIPTION
The parser would call get_cstr() on lexer error messages, which asserts if the message contains null bytes.

Fix this by using get_str() and explicit lengths in the parser. As a side improvement, the lexer now hex-encodes non-printable characters.

Found using AFL.

To test:

```
echo -ne "\0" | ./build/muon internal eval -s -
```