### PR TITLE
gnome: allow boolean 'false' for install_dir_gir/typelib

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -238,7 +238,7 @@ push_install_targets(struct workspace *wk,
 		.install_dirs_is_arr = get_obj_type(wk, install_dirs) == obj_array,
 	};
 
-	assert(ctx.install_dirs_is_arr || get_obj_type(wk, install_dirs) == obj_string);
+	assert(ctx.install_dirs_is_arr || get_obj_type(wk, install_dirs) == obj_string || get_obj_type(wk, install_dirs) == obj_bool);
 
 	if (ctx.install_dirs_is_arr) {
 		struct obj_array *a1 = get_obj_array(wk, filenames);

--- a/src/script/modules/gnome.meson
+++ b/src/script/modules/gnome.meson
@@ -199,8 +199,8 @@ func generate_gir(
     includes listify[str]: [],
     install_gir bool:,
     install_typelib bool:,
-    install_dir_gir str:,
-    install_dir_typelib str:,
+    install_dir_gir bool|str:,
+    install_dir_typelib bool|str:,
     link_with listify[both_libs|build_tgt]: [],
     namespace str:,
     nsversion str:,
@@ -218,6 +218,14 @@ func generate_gir(
         error('nsversion kwarg is required')
     endif
 
+    if typeof(install_dir_gir) == 'bool' and install_dir_gir == true
+        error('install_dir_gir as boolean can only be false')
+    endif
+
+    if typeof(install_dir_typelib) == 'bool' and install_dir_typelib == true
+        error('install_dir_typelib as boolean can only be false')
+    endif
+
     # Determine install directories
     if is_null(install_dir_gir)
         install_dir_gir = get_option('datadir') / 'gir-1.0'
@@ -228,11 +236,19 @@ func generate_gir(
     endif
 
     if is_null(install_gir)
-        install_gir = install
+        if install_dir_gir == false
+            install_gir = false
+        else
+            install_gir = install
+        endif
     endif
 
     if is_null(install_typelib)
-        install_typelib = install
+        if install_dir_typelib == false
+            install_typelib = false
+        else
+            install_typelib = install
+        endif
     endif
 
     # Find required programs


### PR DESCRIPTION
This matches Meson's behavior where `install_dir_gir` and `install_dir_typelib` can be set to `false` to disable installation (though this is deprecated in favor of `install_gir: false`).

This fix is required to build cjs 6.4.0 with muon: https://github.com/linuxmint/cjs/releases/tag/6.4.0

Relevant meson source code: 
https://github.com/mesonbuild/meson/blob/bf3b2f32ecfe4c0b20ca1649cb015c1a3de878ab/mesonbuild/modules/gnome.py#L1143