### PR TITLE
cmake preprocessor fixes

### DIFF
--- a/src/functions/kernel/configure_file.c
+++ b/src/functions/kernel/configure_file.c
@@ -228,6 +228,13 @@ substitute_config_variables(struct workspace *wk, struct configure_file_context 
 				tstr_pushs(wk, out, "@@");
 				continue;
 			} else if (!obj_dict_index_strn(wk, ctx->dict, &in->buf[id_start], i - id_start, &elem)) {
+				if (ctx->syntax & configure_file_syntax_cmakedefine)
+				{
+					// non-existant keys are valid in cmake headers
+					tstr_pushs(wk, out, "");
+					continue;
+				}
+
 				configure_file_log(wk,
 					ctx,
 					id_location,

--- a/src/functions/kernel/configure_file.c
+++ b/src/functions/kernel/configure_file.c
@@ -284,6 +284,7 @@ substitute_config_defines(struct workspace *wk, struct configure_file_context *c
 		location.off = s - ctx->in->buf;
 
 		struct str line = { s, e - s };
+		str_strip_in_place(&line, NULL, 0);
 
 		if (str_startswith(&line, &define)) {
 			obj arr = str_split(wk, &line, 0);

--- a/src/functions/kernel/configure_file.c
+++ b/src/functions/kernel/configure_file.c
@@ -308,7 +308,9 @@ substitute_config_defines(struct workspace *wk, struct configure_file_context *c
 						tstr_pushf(wk, out, "/* #undef %s */\n", get_str(wk, varname)->s);
 					}
 				} else {
-					if (!cmake_bool && !coerce_truthiness(wk, elem)) {
+					if (cmake_bool) {
+						tstr_pushf(wk, out, "#define %s %i\n", get_str(wk, varname)->s, (int)coerce_truthiness(wk, elem));
+					} else if (!coerce_truthiness(wk, elem)) {
 						tstr_pushf(wk, out, "/* #undef %s */\n", get_str(wk, varname)->s);
 					} else {
 						tstr_pushf(wk, out, "#define %s", get_str(wk, varname)->s);

--- a/tests/configure_file/cmake/config.h.in
+++ b/tests/configure_file/cmake/config.h.in
@@ -1,0 +1,110 @@
+// cmakedefine
+
+// undefined
+#cmakedefine noval unreachable
+
+// 1
+#cmakedefine trueval 1
+
+// undefined
+#cmakedefine falseval unreachable
+
+// undefined
+#cmakedefine zeroval unreachable
+
+// 1
+#cmakedefine oneval 1
+
+// 1
+#cmakedefine tenval 1
+
+// 1
+#cmakedefine stringval 1
+
+
+// cmakedefine01
+
+// 0
+#cmakedefine01 boolnoval
+
+// 1
+#cmakedefine01 booltrueval
+
+// 0
+#cmakedefine01 boolfalseval
+
+// 0
+#cmakedefine01 boolzeroval
+
+// 1
+#cmakedefine01 booloneval
+
+// 1
+#cmakedefine01 booltenval
+
+// 1
+#cmakedefine01 boolstringval
+
+// @ substition
+
+// undefined variable, removed
+// @undefval@
+
+// no value, removed
+// @noval@
+
+// 1
+// @trueval@
+
+// 0
+// @falseval@
+
+// 0
+// @zeroval@
+
+// 1
+// @oneval@
+
+// 10
+// @tenval@
+
+// test
+// @stringval@
+
+
+// curly brackets substition
+
+// empty curly brackets, removed
+// this does not work with zig 0.15.2
+// $ {}
+
+// undefined variable, removed
+// ${undefval}
+
+// no value, removed
+// ${noval}
+
+// 1
+// ${trueval}
+
+// 0
+// ${falseval}
+
+// 0
+// ${zeroval}
+
+// 1
+// ${oneval}
+
+// 10
+// ${tenval}
+
+// test
+// ${stringval}
+
+
+// sigil test (no changes)
+#define AT @
+#define ATAT @@
+#define ATATAT @@@
+#define ATATATAT @@@@

--- a/tests/configure_file/cmake/expected_config.h
+++ b/tests/configure_file/cmake/expected_config.h
@@ -1,0 +1,110 @@
+// cmakedefine
+
+// undefined
+/* #undef noval */
+
+// 1
+#define trueval 1
+
+// undefined
+/* #undef falseval */
+
+// undefined
+/* #undef zeroval */
+
+// 1
+#define oneval 1
+
+// 1
+#define tenval 1
+
+// 1
+#define stringval 1
+
+
+// cmakedefine01
+
+// 0
+#define boolnoval 0
+
+// 1
+#define booltrueval 1
+
+// 0
+#define boolfalseval 0
+
+// 0
+#define boolzeroval 0
+
+// 1
+#define booloneval 1
+
+// 1
+#define booltenval 1
+
+// 1
+#define boolstringval 1
+
+// @ substition
+
+// undefined variable, removed
+// 
+
+// no value, removed
+// 
+
+// 1
+// 1
+
+// 0
+// 0
+
+// 0
+// 0
+
+// 1
+// 1
+
+// 10
+// 10
+
+// test
+// test
+
+
+// curly brackets substition
+
+// empty curly brackets, removed
+// this does not work with zig 0.15.2
+// $ {}
+
+// undefined variable, removed
+// 
+
+// no value, removed
+// 
+
+// 1
+// 1
+
+// 0
+// 0
+
+// 0
+// 0
+
+// 1
+// 1
+
+// 10
+// 10
+
+// test
+// test
+
+
+// sigil test (no changes)
+#define AT @
+#define ATAT @@
+#define ATATAT @@@
+#define ATATATAT @@@@

--- a/tests/configure_file/cmake/meson.build
+++ b/tests/configure_file/cmake/meson.build
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: GPL-3.0-only
+
+fs = import('fs')
+
+conf_data = configuration_data()
+conf_data.set10('foo', true)
+conf_data.set('HAVE_FOO', 'foo_content')
+
+conf_data.set10('trueval', true)
+conf_data.set10('falseval', false)
+conf_data.set('zeroval', 0)
+conf_data.set('oneval', 1)
+conf_data.set('tenval', 10)
+conf_data.set('stringval', 'test')
+
+conf_data.set10('booltrueval', true)
+conf_data.set10('boolfalseval', false)
+conf_data.set('boolzeroval', 0)
+conf_data.set('booloneval', 1)
+conf_data.set('booltenval', 10)
+conf_data.set('boolstringval', 'test')
+
+conf_data.set('DOLLAR', '$')
+conf_data.set('TEXT', 'TRAP')
+conf_data.set('STRING', 'TEXT')
+conf_data.set('STRING_AT', '@STRING@')
+conf_data.set('STRING_CURLY', '{STRING}')
+conf_data.set('STRING_VAR', '${STRING}')
+
+conf_data.set('UNDERSCORE', '_')
+conf_data.set('NEST_UNDERSCORE_PROXY', 'UNDERSCORE')
+conf_data.set('NEST_PROXY', 'NEST_UNDERSCORE_PROXY')
+
+configure_file(
+    input: 'config.h.in',
+    output: 'config.h',
+    format: 'cmake',
+    configuration: conf_data,
+)
+
+output = fs.read('@0@/config.h'.format(meson.current_build_dir())).split('\n')
+expected_output = fs.read('expected_config.h').split('\n')
+
+if output.length() != expected_output.length()
+    message(
+        'Output is of size @0@ but expected @1@'.format(output.length(), expected_output.length()),
+    )
+    assert(false)
+endif
+
+foreach i : range(output.length())
+    eq = output[i] == expected_output[i]
+    if not eq
+        p('-----------------\nactual: ', pretty: true)
+        p(output[i], pretty: true)
+        p('!=\nexpected: ', pretty: true)
+        p(expected_output[i], pretty: true)
+        p('-----------------\n', pretty: true)
+    endif
+    assert(eq)
+endforeach

--- a/tests/configure_file/meson.build
+++ b/tests/configure_file/meson.build
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-3.0-only
+
+subdir('cmake')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4,6 +4,7 @@
 add_test_setup('valgrind', exclude_suites: 'project', exe_wrapper: ['valgrind'])
 add_test_setup('no_python', exclude_suites: 'requires_python')
 
+subdir('configure_file')
 subdir('fmt')
 subdir('fuzz')
 subdir('lang')


### PR DESCRIPTION
fixes non-existant keys being errors for cmake headers and boolean cmakdefines not having value.

tested against [Jan200101/cmakedefine-test](https://github.com/Jan200101/cmakedefine-test) which the meson implementation was developed against.

The handy `muon_diff.sh` script creates a diff between the cmake and muon output, the `meson_diff.sh` script can be used to reference what meson does.