### PR TITLE
ld-tcc: support .dll.a files and -l for msys2 system DLLs

### DIFF
--- a/include/backend/common_args.h
+++ b/include/backend/common_args.h
@@ -26,6 +26,8 @@ void ca_get_option_link_args(struct workspace *wk,
 
 obj ca_build_target_joined_args(struct workspace *wk, obj processed_args);
 
+void ca_link_args_to_native(struct workspace *wk, obj comp, obj *args);
+
 bool
 ca_prepare_target_linker_args(struct workspace *wk,
 	obj comp,

--- a/include/toolchains.h
+++ b/include/toolchains.h
@@ -203,6 +203,7 @@ typedef bool ((*compiler_get_arg_func_1srb)(TOOLCHAIN_SIG_1srb));
 	_(shared_module, linker, TOOLCHAIN_PARAMS_0)           \
 	_(soname, linker, TOOLCHAIN_PARAMS_1s)                 \
 	_(start_group, linker, TOOLCHAIN_PARAMS_0)             \
+	_(to_native, linker, TOOLCHAIN_PARAMS_ns)              \
 	_(version, linker, TOOLCHAIN_PARAMS_0)                 \
 	_(whole_archive, linker, TOOLCHAIN_PARAMS_1s)
 

--- a/src/backend/common_args.c
+++ b/src/backend/common_args.c
@@ -637,6 +637,26 @@ ca_setup_optional_b_args_linker(struct workspace *wk,
 	return true;
 }
 
+void
+ca_link_args_to_native(struct workspace *wk, obj comp, obj *args)
+{
+	TSTR(json_before);
+	if (!obj_to_json(wk, *args, &json_before)) {
+		UNREACHABLE;
+	}
+
+	*args = toolchain_linker_to_native(wk, comp, *args);
+
+	TSTR(json_after);
+	if (!obj_to_json(wk, *args, &json_after)) {
+		UNREACHABLE;
+	}
+
+	if (0 != strcmp(json_before.buf, json_after.buf)) {
+		L("to_native from: %s to: %s", json_before.buf, json_after.buf);
+	}
+}
+
 bool
 ca_prepare_target_linker_args(struct workspace *wk,
 	obj comp,
@@ -805,6 +825,15 @@ ca_prepare_target_linker_args(struct workspace *wk,
 			ca_push_linker_args(
 				wk, comp, tgt, toolchain_linker_def(wk, comp, get_cstr(wk, rel)));
 		}
+	}
+
+	switch (tgt->type) {
+	case tgt_shared_module:
+	case tgt_dynamic_library:
+	case tgt_executable:
+		ca_link_args_to_native(wk, comp, &tgt->dep_internal.link_args);
+		break;
+	default: break;
 	}
 
 	return true;

--- a/src/external/pkgconfig_libpkgconf.c
+++ b/src/external/pkgconfig_libpkgconf.c
@@ -50,11 +50,11 @@ muon_pkgconf_init(struct workspace *wk, struct pkgconf_client *c, enum machine_k
 {
 	TracyCZoneAutoS;
 	c->personality = pkgconf_cross_personality_default();
-#if defined(LIBPKGCONF_VERSION) && LIBPKGCONF_VERSION >= 30000
-	pkgconf_client_init(&c->client, error_handler, NULL, c->personality, NULL, env_lookup_handler);
-#else
-	pkgconf_client_init(&c->client, error_handler, NULL, c->personality);
+	pkgconf_client_init(&c->client, error_handler, NULL, c->personality
+#if defined(LIBPKGCONF_VERSION) && LIBPKGCONF_VERSION >= 20991
+		, NULL, env_lookup_handler
 #endif
+	);
 
 	struct obj_array *pkg_config_path;
 	{
@@ -272,16 +272,24 @@ apply_variable(pkgconf_client_t *client, pkgconf_pkg_t *world, void *_ctx, int m
 {
 	struct pkgconf_get_variable_ctx *ctx = _ctx;
 	bool found = false;
-	const char *var;
 	pkgconf_dependency_t *dep = world->required.head->data;
 	pkgconf_pkg_t *pkg = dep->match;
 
 	if (pkg != NULL) {
-		var = pkgconf_tuple_find(client, &pkg->vars, ctx->var);
+#if defined(LIBPKGCONF_VERSION) && LIBPKGCONF_VERSION >= 20995
+		char *var = pkgconf_variable_eval_name(client, &pkg->vars, ctx->var);
+		if (var != NULL) {
+			*ctx->res = make_str(ctx->wk, var);
+			free(var); //FIXME: verify this is the correct free function
+			found = true;
+		}
+#else
+		const char *var = pkgconf_tuple_find(client, &pkg->vars, ctx->var);
 		if (var != NULL) {
 			*ctx->res = make_str(ctx->wk, var);
 			found = true;
 		}
+#endif
 	}
 
 	return found;

--- a/src/functions/compiler.c
+++ b/src/functions/compiler.c
@@ -225,6 +225,10 @@ compiler_check(struct workspace *wk, struct compiler_check_opts *opts, const cha
 		obj_array_extend(wk, compiler_args, opts->args);
 	}
 
+	if (opts->mode == compiler_check_mode_link || opts->mode == compiler_check_mode_run) {
+		ca_link_args_to_native(wk, comp, &compiler_args);
+	}
+
 	bool ret = false;
 	struct run_cmd_ctx cmd_ctx = { 0 };
 

--- a/src/script/runtime/toolchains.meson
+++ b/src/script/runtime/toolchains.meson
@@ -269,6 +269,99 @@ toolchain.register_linker(
     },
 )
 
+tcc_dll_cache := {}
+tcc_dlltool := null
+tcc_dlla_fallbacks := null
+DLL_INVALID := null
+msys_libpath := null
+
+func try_tcc_dll(dlla_path str, candidate_dll_path str) -> str|null
+    if fs.exists(candidate_dll_path)
+        tcc_dll_cache[dlla_path] = candidate_dll_path
+        return candidate_dll_path
+    endif
+    return DLL_INVALID
+endfunc
+
+func dlltool(dlla str) -> any
+    dllname := ''
+    if tcc_dlltool == null
+        tcc_dlltool = find_program('dlltool', 'llvm-dlltool', required: false)
+    endif
+    if tcc_dlltool.found()
+        dllname = run_command(tcc_dlltool, '-I', dlla, check: false).stdout().strip()
+    else
+        if tcc_dlla_fallbacks == null
+            tcc_dlla_fallbacks = {
+                'libarchive.dll.a': 'libarchive-13.dll',
+                'libcurl.dll.a': 'libcurl-4.dll',
+                'libpkgconf.dll.a': 'libpkgconf-7.dll',
+                'libz.dll.a': 'zlib1.dll',
+            }
+        endif
+        basename := fs.name(dlla)
+        if tcc_dlla_fallbacks.has_key(basename)
+            dllname = tcc_dlla_fallbacks[basename]
+            warning(f'dlltool not found. Using "@dllname@" fallback for "@dlla@"')
+        else
+            warning(f'dlltool not found. No fallback for "@dlla@"')
+        endif
+    endif
+    return dllname
+endfunc
+
+func try_convert_dlla_to_dll(dlla str) -> str
+    assert(dlla.endswith('.dll.a'))
+    if tcc_dll_cache.has_key(dlla)
+        return tcc_dll_cache[dlla]
+    endif
+
+    dllpath := DLL_INVALID
+    dlla_arr := dlla.split('/')
+
+    # Get the .dll file base name which may differ from the .dll.a name
+    dllname := dlltool(dlla)
+    if dllname == '' or dllname.to_lower().startswith('(null)')
+        # No dll name found - try dropping the .a suffix from .dll.a
+        dllname = dlla_arr[-1].substring(0, -2)
+    endif
+
+    # Try .dll in same directory
+    dllpath = try_tcc_dll(dlla, '/'.join(dlla_arr.slice(0, -1) + [dllname]))
+
+    # Try bin sibling of the lib dir if present
+    if dllpath == DLL_INVALID and dlla_arr.length() >= 2 and dlla_arr[-2] == 'lib'
+        dllpath = try_tcc_dll(dlla, '/'.join(dlla_arr.slice(0, -2) + ['bin', dllname]))
+    endif
+
+    # Try $MSYSTEM_PREFIX/bin
+    msys_subdir := 0
+    if dllpath == DLL_INVALID
+        i := 0
+        foreach sub : dlla_arr
+            i += 1
+            if sub in ['msys64', 'msys2']
+                if msys_subdir == 0
+                    msys_subdir = i
+                endif
+            elif sub in ['mingw64', 'clang64', 'ucrt64', 'mingw32']
+                dllpath = try_tcc_dll(dlla, '/'.join(dlla_arr.slice(0, i) + ['bin', dllname]))
+                break
+            endif
+        endforeach
+    endif
+
+    # Try msys2 root usr/bin
+    if dllpath == DLL_INVALID and msys_subdir > 0
+        dllpath = try_tcc_dll(
+            dlla,
+            '/'.join(dlla_arr.slice(0, msys_subdir) + ['usr', 'bin', dllname]),
+        )
+    endif
+
+    return dllpath == DLL_INVALID ? dlla : dllpath
+endfunc
+
 toolchain.register_linker(
     'ld-tcc',
     inherit: 'ld-posix',
@@ -299,6 +392,56 @@ toolchain.register_linker(
         'shared_module': ['-shared'],
         'soname': func(_c compiler, s1 str) -> list[str]
             return ['-soname', s1]
+        endfunc,
+        'to_native': func(c compiler, args list[str]) -> list[str]
+            if c.machine().system() != 'windows'
+                return args
+            endif
+            # tcc cannot handle msys2 .dll.a files, so convert .dll.a paths
+            # to .dll paths with dlltool and msys2 directory heuristics.
+            ret := []
+            expecting_l_arg := false
+            foreach arg : args
+                # Convert -lxxx flags to absolute msys2 libxxx.dll.a path
+                if expecting_l_arg
+                    arg = '-l' + arg
+                    expecting_l_arg = false
+                endif
+                l_arg := ''
+                if arg.startswith('-l')
+                    l_arg = arg.substring(2)
+                    if l_arg == ''
+                        expecting_l_arg = true
+                        continue
+                    endif
+                    if msys_libpath == null
+                        MSYSTEM_PREFIX := 'MSYSTEM_PREFIX'
+                        libpath := run_command('cmd', '/c', 'set', MSYSTEM_PREFIX, check: false).stdout().strip()
+                        if libpath.startswith(MSYSTEM_PREFIX + '=')
+                            msys_libpath = libpath.substring(MSYSTEM_PREFIX.length() + 1)
+                        endif
+                    endif
+                    if msys_libpath != null and msys_libpath.length() > 0
+                        arg = msys_libpath / 'lib' / 'lib' + l_arg + '.dll.a'
+                        # fallthrough to .dll conversion
+                    endif
+                endif
+                # Convert .dll.a path to its absolute .dll path
+                if arg.endswith('.dll.a') and not arg.contains('-Wl,')
+                    if not fs.is_absolute(arg)
+                        # cwd is meson.current_source_dir during setup
+                        # so convert build dir relative paths to absolute.
+                        arg = fs.canonicalize(fs.make_absolute(meson.current_build_dir() / arg))
+                    endif
+                    arg = try_convert_dlla_to_dll(arg)
+                endif
+                if arg.endswith('.dll.a') and l_arg != ''
+                    # .dll not found - reconstitute original -l argument
+                    arg = '-l' + l_arg
+                endif
+                ret += arg
+            endforeach
+            return ret
         endfunc,
         'version': ['-v'],
         'whole_archive': func(_c compiler, s1 str) -> list[str]

--- a/src/toolchains.c
+++ b/src/toolchains.c
@@ -1227,6 +1227,7 @@ toolchain_handler_info_init(struct workspace *wk)
 	doc(implib_suffix, linker, .desc = "Linker specific import library suffix for DLLs. Defaults to '-implib.lib' if not provided.");
 	doc(input_output, linker, .desc = "Passed in `input` and `output` and orders them properly, optionally adding additional flags.");
 	doc(lib, linker, .desc = "`-l`");
+	doc(to_native, linker, .desc = "Convert arguments to linker-specific native format.");
 	doc(no_undefined, linker, .desc = "`--no-undefined`");
 	doc(pgo, linker, .desc = "", .enum_arg = "enum compiler_pgo_stage");
 	doc(rpath, linker, .desc = "`-rpath`");

--- a/tools/ci/tcc-boot-build-test.sh
+++ b/tools/ci/tcc-boot-build-test.sh
@@ -9,11 +9,9 @@ BUILD=t
 TCC=tcc
 export CC=$TCC
 export NINJA=samu  # Avoid ninja on msys2 - incompatible with muon.
-export LDFLAGS="-L `cygpath -wam $BUILD` $LDFLAGS"  # Pick up .def's created below
 DEST_INC=$BUILD/include
 MINGW=$MINGW_PREFIX
 [ -d "$MINGW" ] && echo "Using MINGW_PREFIX=$MINGW" || "MINGW_PREFIX directory $MINGW not found."
-export PKG_CONFIG_PATH=$(cygpath -u -a $BUILD):$PKG_CONFIG_PATH
 export CFLAGS="$CFLAGS -I $(cygpath -wam $DEST_INC)"
 rm -rf $BUILD && \
 mkdir -p $BUILD && \
@@ -25,12 +23,6 @@ cp -v     $MINGW/include/archive.h       $DEST_INC/ && \
 cp -v     $MINGW/include/archive_entry.h $DEST_INC/ && \
 cp -v     $MINGW/include/zlib.h          $DEST_INC/ && \
 cp -v     $MINGW/include/zconf.h         $DEST_INC/ && \
-$TCC -impdef $MINGW/bin/libarchive-13.dll -v -o $BUILD/libarchive.def && \
-$TCC -impdef $MINGW/bin/libcurl-4.dll     -v -o $BUILD/libcurl.def && \
-$TCC -impdef $MINGW/bin/libpkgconf-7.dll  -v -o $BUILD/libpkgconf.def && \
-$TCC -impdef $MINGW/bin/zlib1.dll         -v -o $BUILD/zlib.def && \
-$TCC -impdef $MINGW/bin/zlib1.dll         -v -o $BUILD/z.def && \
-sed "s%Libs:.*%Libs: `cygpath -wam $MINGW/bin/zlib1.dll`%" $MINGW/lib/pkgconfig/zlib.pc > $BUILD/zlib.pc && \
 ./bootstrap.sh $BUILD && \
 ./$BUILD/muon-bootstrap build -Ddisable-test-languages=cpp,objc $BUILD && \
 ./$BUILD/muon -C $BUILD test -v -R -o term


### PR DESCRIPTION
* implement `'to_native'` linker handler to change link arguments
  - will dbg log if the link args array changed
* supports link_args, LDFLAGS, link feature tests, find_library
* passes formerly skipped "meson-tests/common/171 initial c_args"
* simplifies building of muon itself with tcc on windows/msys2
  - no longer necessary to use custom .def and .pc files
* no noticeable perf impact