### PR TITLE
use msys2-safe free function for libpkgconf 3.x pkgconf_variable_eval_name

### DIFF
--- a/src/external/pkgconfig_libpkgconf.c
+++ b/src/external/pkgconfig_libpkgconf.c
@@ -280,8 +280,15 @@ apply_variable(pkgconf_client_t *client, pkgconf_pkg_t *world, void *_ctx, int m
 		char *var = pkgconf_variable_eval_name(client, &pkg->vars, ctx->var);
 		if (var != NULL) {
 			*ctx->res = make_str(ctx->wk, var);
-			free(var);
 			found = true;
+
+			// Guarantee we call the correct free function corresponding
+			// to the malloc used by the msys2 libpkgconf DLL.
+			// This is portable across all platforms and compilers.
+			// A more efficient alternative using the private API would be:
+			//  pkgconf_buffer_finalize(&(pkgconf_buffer_t){.base = var, .end = 0});
+			pkgconf_buffer_t var_buf = *PKGCONF_BUFFER_FROM_STR_NONNULL(var);
+			pkgconf_buffer_finalize(&var_buf);
 		}
 #else
 		const char *var = pkgconf_tuple_find(client, &pkg->vars, ctx->var);


### PR DESCRIPTION
* Prevent crashes when muon built in one msys2 environment like /clang64 with clang is used to build a project in another msys2 environment like /mingw64.
* Guarantee the use of the correct free function that corresponds to the malloc/calloc/realloc/strndup used within the same libpkgconf DLL.
* Less error prone solution than copying system DLLs to same directory as muon.exe or fiddling with PATH or launching muon via a script.