### PR TITLE
muon analyze: convert some op_in errors to warnings for combo options

### DIFF
--- a/src/lang/string.c
+++ b/src/lang/string.c
@@ -276,15 +276,6 @@ check_str_enum(struct workspace *wk, obj l, enum obj_type l_t, obj r, enum obj_t
 	}
 
 	switch (op) {
-	case check_str_enum_op_eq:
-		if (r_t == obj_string) {
-			if (!obj_array_in(wk, values, r)) {
-				vm_warning(wk, "%o is not one of %o", r, values);
-				return false;
-			}
-			return true;
-		}
-		break;
 	case check_str_enum_op_in:
 		if (r_t == obj_array) {
 			obj v;
@@ -303,6 +294,15 @@ check_str_enum(struct workspace *wk, obj l, enum obj_type l_t, obj r, enum obj_t
 					vm_warning(wk, "%o is not one of %o", k, values);
 					return false;
 				}
+			}
+			return true;
+		}
+		// fallthrough
+	case check_str_enum_op_eq:
+		if (r_t == obj_string) {
+			if (!obj_array_in(wk, values, r)) {
+				vm_warning(wk, "%o is not one of %o", r, values);
+				return false;
 			}
 			return true;
 		}

--- a/src/lang/vm.c
+++ b/src/lang/vm.c
@@ -2021,7 +2021,16 @@ vm_op_in(struct workspace *wk)
 			[obj_string] = { tc_string, tc_bool },
 		};
 		if (!typecheck_typeinfo_operands(wk, b, a, &res, map)) {
-			goto type_err;
+			if (a_t == obj_string) {
+				if (check_str_enum(wk, b, b_t, a, a_t, check_str_enum_op_in)) {
+					res = obj_bool_true;
+				} else {
+					// A warning was issued by check_str_enum.
+					res = make_typeinfo(wk, tc_bool);
+				}
+			} else {
+				goto type_err;
+			}
 		}
 		break;
 	}

--- a/tests/project/muon/str/meson.build
+++ b/tests/project/muon/str/meson.build
@@ -9,3 +9,29 @@ assert(foo.substring(64) == '')
 assert(foo.substring(-64) == 'bar')
 assert(foo.substring(0, 64) == 'bar')
 assert(foo.substring(64, 0) == '')
+
+choices = ['foo', 'buz']
+
+assert('buz' in choices)
+assert(not ('bug' in choices))
+
+# enum-like combo option strings
+buildtype = get_option('buildtype')
+sanitize = get_option('b_sanitize')
+
+# No errors or warnings in analyze
+assert(('address' == sanitize) in [true, false])
+assert(('address' in sanitize) in [true, false])
+assert(('debug' == buildtype) in [true, false])
+assert(('debug' in buildtype) in [true, false])
+assert(('release' == buildtype) in [true, false])
+assert(('release' in buildtype) in [true, false])
+
+# These combo option comparisons will issue warnings in analyze
+# but will run without error or warning in setup/build
+assert(('nope' == sanitize) in [true, false])
+assert(('nope' in sanitize) in [true, false])
+assert(('lease' == buildtype) in [true, false])
+assert(('lease' in buildtype) in [true, false])
+assert(('bug' == buildtype) in [true, false])
+assert(('bug' in buildtype) in [true, false])


### PR DESCRIPTION
* fewer analyze false positives
* muon setup/build unaffected - still runs all string "in" operations without error/warning.